### PR TITLE
update readme to reflect open-sourcing of the new tldraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-> **Note** We're between versions! The code in this repository is for the **original version** of tldraw, which is hosted at [old.tldraw.com](https://old.tldraw.com). The new version (hosted at [tldraw.com](https://tldraw.com)) is not yet open source. It is _distributed_ however, and you can read more about the new version on **the new docs site** at [docs.tldraw.dev](https://docs.tldraw.dev). This should all be cleaned up soon. 🚧 
+> **Note**<br>
+The code in this repository is for the **original version** of tldraw, which is hosted at [old.tldraw.com](https://old.tldraw.com). The code for the **new version** (hosted at [tldraw.com](https://tldraw.com)) can be found in the main [tldraw repo](https://github.com/tldraw/tldraw).
 
 ---
 


### PR DESCRIPTION
**Don't merge until we open-source the new tldraw.**

This PR updates the readme of the v1 tldraw repo to reflect the open-sourcing of the new tldraw.